### PR TITLE
Plat 319 automate build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install yarn
         uses: borales/actions-yarn@v2.3.0
         with:
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Modern Formik Fields
 
+## 1.3.1 Unreleased
+
+- [PLAT-319] Fix automated build including dist files
+
 ## 1.3.0
 
 - [PLAT-318] Fix deploy with github actions

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![npm version](https://badge.fury.io/js/%40sealink%2Fmodern-formik-fields.svg)](https://badge.fury.io/js/%40sealink%2Fmodern-formik-fields)
-[![Coverage Status](https://coveralls.io/repos/github/sealink/modern-formik-fields/badge.svg?branch=master)](https://coveralls.io/github/sealink/modern-formik-fields?branch=master)
 [![Build Status](https://github.com/sealink/modern-formik-fields/workflows/Build%20and%20Test/badge.svg?branch=master)](https://github.com/sealink/modern-formik-fields/actions)
 
 ### WHY

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sealink/modern-formik-fields",
-  "version": "1.3.0",
+  "version": "1.3.1.alpha-2",
   "description": "A set of components that can be passed to Formik to create useful custom fields.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sealink/modern-formik-fields",
-  "version": "1.3.1.alpha-2",
+  "version": "1.3.1.alpha.2",
   "description": "A set of components that can be passed to Formik to create useful custom fields.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sealink/modern-formik-fields",
-  "version": "1.3.1.alpha.2",
+  "version": "1.3.1-alpha.3",
   "description": "A set of components that can be passed to Formik to create useful custom fields.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "rollup -c --environment BUILD:production",
     "storybook": "install-self-peers -- --ignore-scripts && start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "install-peers": "install-self-peers -- --ignore-scripts"
+    "install-peers": "install-self-peers -- --ignore-scripts",
+    "prepublish": "yarn run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### WHY

The build did not have a prepublish step so the published package had no dist files which ain't good.